### PR TITLE
add Text as valid target for press events

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -88,6 +88,7 @@ const eventMap = {
       'TouchableOpacity',
       'TouchableWithoutFeedback',
       'TouchableNativeFeedback',
+      'Text',
     ],
   },
   press: {
@@ -100,6 +101,7 @@ const eventMap = {
       'TouchableOpacity',
       'TouchableWithoutFeedback',
       'TouchableNativeFeedback',
+      'Text',
     ],
   },
   pressIn: {
@@ -112,6 +114,7 @@ const eventMap = {
       'TouchableWithoutFeedback',
       'TouchableNativeFeedback',
       'YellowBoxPressable',
+      'Text',
     ],
   },
   pressOut: {
@@ -124,6 +127,7 @@ const eventMap = {
       'TouchableWithoutFeedback',
       'TouchableNativeFeedback',
       'YellowBoxPressable',
+      'Text',
     ],
   },
   momentumScrollBegin: {


### PR DESCRIPTION
Text elements were not set as valid targets for press events.  This diff fixes that.

Related issue:
https://github.com/bcarroll22/native-testing-library/issues/3